### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/Noel-Schmidt/snappo/security/code-scanning/1](https://github.com/Noel-Schmidt/snappo/security/code-scanning/1)

To fix this issue, you should add a `permissions` block to the workflow. This block can be added at the top level of the workflow file (recommended if all jobs have the same requirements) or under the `build` job if only that job needs permission restrictions. The minimal permission needed for typical CI operations such as checking out code and running builds/tests is `contents: read`. You should add a block at the workflow root immediately below the `name` and before the `on` key, as per best practices. No other changes are needed; this edit will apply the principle of least privilege without changing any workflow functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
